### PR TITLE
Add .editorconfig to have some formatting uniformity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Adding a `.editorconfig` allows the IDE's to do some basic auto formating.
This file is vendor/IDE neutral and supported by a few.
See https://editorconfig.org/

I've configured hard tabs for all sources (.c/.h/cmake) with a 4 char indentation.
It seems like the oni sources are formatted that way, so it makes sense imho.