### PR TITLE
UB fixes

### DIFF
--- a/BungieFrameWork/BFW_Headers/BFW_BinaryData.h
+++ b/BungieFrameWork/BFW_Headers/BFW_BinaryData.h
@@ -66,15 +66,16 @@ typedef struct BDtMethods
 #define BDmGetByteFromBuffer(src,dst,type,swap_it)					\
 			1;														\
 			do {													\
-			(dst) = *((type *)(src));								\
-			*(UUtUns8**)&(src) += 1;									\
+			memcpy(&(dst), (src), sizeof(type));					\
+			*(UUtUns8**)&(src) += 1;								\
 			} while (0)
 
 #define BDmWriteByteToBuffer(buf,val,type,num_bytes,write_big)		\
 			1;														\
 			do {													\
-			*((type*)(buf)) = (val);								\
-			*(UUtUns8**)&(buf) += 1;									\
+			type tmp = (val);										\
+			memcpy((buf), &tmp, sizeof(type));						\
+			*(UUtUns8**)&(buf) += 1;								\
 			UUmAssert(sizeof(type) == 1);							\
 			UUmAssert((num_bytes) >= 1);							\
 			(num_bytes) -= 1;										\
@@ -82,13 +83,13 @@ typedef struct BDtMethods
 
 #define BDmSkip4BytesFromBuffer(src)								\
 			4; do {													\
-			*(UUtUns8**)&(src) += 4;									\
+			*(UUtUns8**)&(src) += 4;								\
 			} while(0)	
 
 #define BDmGet4BytesFromBuffer(src,dst,type,swap_it)				\
 			4;														\
 			do {													\
-			(dst) = *((type*)(src));								\
+			memcpy(&(dst), (src), sizeof(type));					\
 			*(UUtUns8**)&(src) += sizeof(type);						\
 			if ((swap_it)) { UUrSwap_4Byte(&(dst)); }				\
 			} while (0)
@@ -96,7 +97,8 @@ typedef struct BDtMethods
 #define BDmWrite4BytesToBuffer(buf,val,type,num_bytes,write_big)	\
 			4;														\
 			do {													\
-			*((type*)(buf)) = (val);								\
+			type tmp = (val);										\
+			memcpy((buf), &tmp, sizeof(type));						\
 			if (write_big) { UUmSwapBig_4Byte(buf); } else { UUmSwapLittle_4Byte(buf); } \
 			*(UUtUns8**)&(buf) += sizeof(type);						\
 			UUmAssert((num_bytes) >= sizeof(type));					\
@@ -111,7 +113,7 @@ typedef struct BDtMethods
 #define BDmGet2BytesFromBuffer(src,dst,type,swap_it)				\
 			2;														\
 			do {													\
-			(dst) = *((type*)(src));								\
+			memcpy(&(dst), (src), sizeof(type));					\
 			*(UUtUns8**)&(src) += sizeof(type);						\
 			if ((swap_it)) { UUrSwap_2Byte(&(dst)); }				\
 			} while (0)
@@ -119,7 +121,8 @@ typedef struct BDtMethods
 #define BDmWrite2BytesToBuffer(buf,val,type,num_bytes,write_big)	\
 			2;														\
 			do {													\
-			*((type*)(buf)) = (val);								\
+			type tmp = (val);										\
+			memcpy((buf), &tmp, sizeof(type));						\
 			if (write_big) { UUmSwapBig_2Byte(buf); } else { UUmSwapLittle_2Byte(buf); } \
 			*(UUtUns8**)&(buf) += sizeof(type);						\
 			UUmAssert((num_bytes) >= sizeof(type));					\

--- a/BungieFrameWork/BFW_Headers/BFW_Image.h
+++ b/BungieFrameWork/BFW_Headers/BFW_Image.h
@@ -51,6 +51,14 @@
 	#define IMcShade_Gray25				(0xFF3F3F3F)
 	typedef UUtUns32 IMtShade;
 
+	static inline IMtShade MakeShadeARGB(UUtUns8 a, UUtUns8 r, UUtUns8 g, UUtUns8 b)
+	{
+		return ((IMtShade)a << 24) |
+		       ((IMtShade)r << 16) |
+		       ((IMtShade)g <<  8) |
+		       ((IMtShade)b <<  0) ;
+	}
+
 	typedef tm_enum IMtPixelType
 	{
 		IMcPixelType_ARGB4444,		// 2bytes per pixel

--- a/BungieFrameWork/BFW_Headers/BFW_Motoko.h
+++ b/BungieFrameWork/BFW_Headers/BFW_Motoko.h
@@ -101,7 +101,7 @@ extern "C" {
 	#define M3cMaxNumEngines			(2)
 	#define M3cMaxNameLen				(64)
 	
-	#define M3cMaxAlpha					(255)
+	#define M3cMaxAlpha					((UUtUns32)255)
 	
 	#define M3cBBoxSideBV_PosX			1 // S.S. (1 << 0)
 	#define M3cBBoxSideBV_NegX			2 // S.S. (1 << 1)

--- a/BungieFrameWork/BFW_Headers/BFW_Particle3.h
+++ b/BungieFrameWork/BFW_Headers/BFW_Particle3.h
@@ -944,9 +944,9 @@ extern const P3tString P3gEventName[P3cMaxNumEvents];
 
 #define P3cLensFrames_TypeOffset	16
 #define P3cLensFrames_TypeBits		16
-#define P3cLensFrames_TypeMask		(((1 << P3cLensFrames_TypeBits) - 1) << P3cLensFrames_TypeOffset)
+#define P3cLensFrames_TypeMask		(((1u << P3cLensFrames_TypeBits) - 1) << P3cLensFrames_TypeOffset)
 #define P3cLensFrames_FrameBits		16
-#define P3cLensFrames_FrameMask		((1 << P3cLensFrames_FrameBits) - 1)
+#define P3cLensFrames_FrameMask		((1u << P3cLensFrames_FrameBits) - 1)
 
 enum {
 	P3cLensFrames_Unset			= (0 << P3cLensFrames_TypeOffset),
@@ -1962,7 +1962,7 @@ typedef UUtUns32 P3tParticleReference;
 #define P3cParticleReference_BlockMask		((1 << P3cParticleReference_BlockBits) - 1)
 
 #define P3cParticleReference_Null			0
-#define P3cParticleReference_Valid			(1 << 31)
+#define P3cParticleReference_Valid			(1u << 31)
 
 #define P3mUnpackParticleReference(ref, classptr, particleptr) {									\
 	UUtUns32 classval, indexval, blockval;															\

--- a/BungieFrameWork/BFW_Source/BFW_Particle/BFW_Particle3.c
+++ b/BungieFrameWork/BFW_Source/BFW_Particle/BFW_Particle3.c
@@ -1133,7 +1133,7 @@ UUtPerformanceTimer *P3g_ParticleCollision = NULL;
  * routines
  */
 
-static P3rPointVisible(M3tPoint3D *inPoint, float inTolerance)
+static UUtBool P3rPointVisible(M3tPoint3D *inPoint, float inTolerance)
 {
 	UUtBool lensflare_visible = AKrEnvironment_PointIsVisible(inPoint);
 

--- a/BungieFrameWork/BFW_Source/BFW_ScriptLang/BFW_ScriptLang.c
+++ b/BungieFrameWork/BFW_Source/BFW_ScriptLang/BFW_ScriptLang.c
@@ -223,7 +223,8 @@ SLrScript_ExecuteOnce(
 	SLtErrorContext				errorContext;
 	SLtParameter_Actual			local_buffer[SLcScript_MaxNumParams];
 
-	UUrMemory_MoveFast(inParameterList, local_buffer, sizeof(SLtParameter_Actual) * inParameterListLength);
+	if (inParameterListLength)
+		UUrMemory_MoveFast(inParameterList, local_buffer, sizeof(SLtParameter_Actual) * inParameterListLength);
 	
 	errorContext.fileName = "(called from engine)";
 	errorContext.funcName = UUrMemory_String_GetStr(SLgLexemMemory, inName);

--- a/BungieFrameWork/BFW_Source/BFW_TextSystem/BFW_TextSystem.c
+++ b/BungieFrameWork/BFW_Source/BFW_TextSystem/BFW_TextSystem.c
@@ -726,6 +726,7 @@ TSiString_GetNextCharacter(
 	UUtUns16			character;
 	
 	character = (UUtUns16)((UUtUns8)inString[0] << 8);
+	if (character == 0)  return character;
 	character |= (UUtUns16)((UUtUns8)inString[1]);
 	
 	if (TSiCharacter_IsDoubleByte(character) == UUcFalse)
@@ -735,26 +736,6 @@ TSiString_GetNextCharacter(
 
 	return character;
 }
-
-// ----------------------------------------------------------------------
-static UUtUns16
-TSiString_GetPrevCharacter(
-	const char			*inString)
-{
-	UUtUns16			character;
-	
-	character = *((UUtUns16*)(inString - 2));
-	
-	if (TSiCharacter_IsDoubleByte(character) == UUcFalse)
-	{
-		character &= 0x00FF;
-	}
-	
-	return character;
-}
-
-
-
 
 // ======================================================================
 #if 0 

--- a/OniProj/OniGameSource/Oni_AI/Oni_AI2.c
+++ b/OniProj/OniGameSource/Oni_AI/Oni_AI2.c
@@ -873,7 +873,7 @@ UUtError AI2rInitializeCharacter(ONtCharacter *ioCharacter, const OBJtOSD_Charac
 		ioCharacter->ai2State.combatSettings.flags = combat_data.flags;
 		ioCharacter->ai2State.combatSettings.medium_range = combat_data.medium_range;
 		
-		for (itr = 0; itr < AI2cCombatRange_Max; itr++) {
+		for (itr = 0; itr < AI2cCombatRange_NumStoredRanges; itr++) {
 			ioCharacter->ai2State.combatSettings.behavior[itr] = (AI2tBehaviorType)combat_data.behavior[itr];
 		}
 
@@ -895,7 +895,7 @@ UUtError AI2rInitializeCharacter(ONtCharacter *ioCharacter, const OBJtOSD_Charac
 		// set up default combat settings
 		ioCharacter->ai2State.combatSettings.flags = 0;
 		ioCharacter->ai2State.combatSettings.medium_range = AI2cCombatSettings_DefaultMediumRange;
-		for (itr = 0; itr < AI2cCombatRange_Max; itr++) {
+		for (itr = 0; itr < AI2cCombatRange_NumStoredRanges; itr++) {
 			ioCharacter->ai2State.combatSettings.behavior[itr] = AI2cCombatSettings_DefaultBehavior;
 		}
 		ioCharacter->ai2State.combatSettings.melee_when = AI2cCombatSettings_DefaultMeleeWhen;

--- a/OniProj/OniGameSource/Oni_AI/Oni_AI2_Combat.h
+++ b/OniProj/OniGameSource/Oni_AI/Oni_AI2_Combat.h
@@ -169,7 +169,7 @@ typedef struct AI2tCombatSettings {
 	UUtUns16					pad;
 	float						medium_range;
 	float						short_range;
-	AI2tBehaviorType			behavior[AI2cCombatRange_Max];
+	AI2tBehaviorType			behavior[AI2cCombatRange_NumStoredRanges];
 	AI2tFightType				melee_when;
 	AI2tNoGunBehavior			no_gun;
 	float						pursuit_distance;

--- a/OniProj/OniGameSource/Oni_AI/Oni_AI2_MeleeProfile.h
+++ b/OniProj/OniGameSource/Oni_AI/Oni_AI2_MeleeProfile.h
@@ -67,7 +67,7 @@ enum {
 // type of move
 #define AI2cMoveType_Shift				28
 #define AI2cMoveType_Bits				(32 - AI2cMoveType_Shift)
-#define AI2cMoveType_Mask				(((1 << AI2cMoveType_Bits) - 1) << AI2cMoveType_Shift)
+#define AI2cMoveType_Mask				(((1u << AI2cMoveType_Bits) - 1) << AI2cMoveType_Shift)
 
 enum {
 	AI2cMoveType_Attack								= (0 << AI2cMoveType_Shift),

--- a/OniProj/OniGameSource/Oni_Level.c
+++ b/OniProj/OniGameSource/Oni_Level.c
@@ -1213,7 +1213,7 @@ IMtShade ONrLevel_ObjectGunk_GetShade(ONtObjectGunk	*inObjectGunk)
 	UUmAssert(g <= 0xFF);
 	UUmAssert(b <= 0xFF);
 
-	shade = (0xFF << 24) | (r << 16) | (g << 8) | (b << 0);
+	shade = MakeShadeARGB(0xFF, (UUtUns8)r, (UUtUns8)g, (UUtUns8)b);
 
 exit:
 	return shade;

--- a/OniProj/OniGameSource/Oni_Object/Oni_Object.h
+++ b/OniProj/OniGameSource/Oni_Object/Oni_Object.h
@@ -25,6 +25,7 @@
 #include "Oni_AI2_Patrol.h"
 #include "Oni_AI2_MeleeProfile.h"
 #include "Oni_AI2_Pursuit.h"
+#include "Oni_AI2_Combat.h"
 
 #include "Oni_Event.h"
 
@@ -820,7 +821,7 @@ typedef struct OBJtOSD_Combat
 	UUtUns16				id;
 	UUtUns16				flags;
 	float					medium_range;
-	UUtUns32				behavior[5];
+	UUtUns32				behavior[AI2cCombatRange_NumStoredRanges];
 	UUtUns32				melee_when;
 	UUtUns32				no_gun;
 	float					short_range;

--- a/OniProj/OniGameSource/Oni_Object/object_types/OT_Combat.c
+++ b/OniProj/OniGameSource/Oni_Object/object_types/OT_Combat.c
@@ -255,7 +255,7 @@ OBJiCombat_SetDefaults(
 
 	outOSD->osd.combat_osd.flags = 0;
 	outOSD->osd.combat_osd.medium_range = AI2cCombatSettings_DefaultMediumRange;
-	for (itr = 0; itr < 5; itr++) {
+	for (itr = 0; itr < AI2cCombatRange_NumStoredRanges; itr++) {
 		outOSD->osd.combat_osd.behavior[itr] = AI2cCombatSettings_DefaultBehavior;
 	}
 	outOSD->osd.combat_osd.melee_when = AI2cCombatSettings_DefaultMeleeWhen;
@@ -410,7 +410,7 @@ OBJiCombat_SetOSD(
 	com_osd->id = inOSD->osd.combat_osd.id;
 	com_osd->flags = inOSD->osd.combat_osd.flags;
 
-	for (itr = 0; itr < 5; itr++) {
+	for (itr = 0; itr < AI2cCombatRange_NumStoredRanges; itr++) {
 		com_osd->behavior[itr] = inOSD->osd.combat_osd.behavior[itr];
 	}
 

--- a/OniProj/OniGameSource/Oni_Windows/Oni_Win_AI_Combat.c
+++ b/OniProj/OniGameSource/Oni_Windows/Oni_Win_AI_Combat.c
@@ -54,8 +54,8 @@ OWrEditCombat_Callback(
 		cEditCombat_AlarmFightTimer	= 605
 	};
 
-	WMtPopupMenu *behavior_menu[5];
-	WMtText		 *behavior_prompt[5];
+	WMtPopupMenu *behavior_menu[AI2cCombatRange_NumStoredRanges];
+	WMtText		 *behavior_prompt[AI2cCombatRange_NumStoredRanges];
 	WMtEditField *id_edit				= WMrDialog_GetItemByID(inDialog, cEditCombat_ID);
 	WMtEditField *name_edit				= WMrDialog_GetItemByID(inDialog, cEditCombat_Name);
 	WMtEditField *range_edit			= WMrDialog_GetItemByID(inDialog, cEditCombat_MedRange);
@@ -86,7 +86,7 @@ OWrEditCombat_Callback(
 	{
 		UUtUns16 itr;
 
-		for(itr = 0; itr < 5; itr++) {
+		for(itr = 0; itr < AI2cCombatRange_NumStoredRanges; itr++) {
 			behavior_prompt[itr] = WMrDialog_GetItemByID(inDialog, cEditCombat_Prompt_Base + itr);
 			behavior_menu[itr] = WMrDialog_GetItemByID(inDialog, cEditCombat_Menu_Base + itr);
 		}
@@ -107,7 +107,7 @@ OWrEditCombat_Callback(
 			{
 				UUtUns32 init_itr;
 
-				for(init_itr = 0; init_itr < 5; init_itr++) 
+				for(init_itr = 0; init_itr < AI2cCombatRange_NumStoredRanges; init_itr++) 
 				{
 					WMrPopupMenu_AppendStringList(behavior_menu[init_itr], AI2cBehavior_Max, AI2cBehaviorName);
 					WMrPopupMenu_SetSelection(behavior_menu[init_itr], (UUtUns16) combat_osd->behavior[init_itr]);
@@ -147,7 +147,7 @@ OWrEditCombat_Callback(
 
 				dirty = UUcTrue;
 
-				if ((menu_window_id >= cEditCombat_Menu_Base) && (menu_window_id < (cEditCombat_Menu_Base + 5))) {
+				if ((menu_window_id >= cEditCombat_Menu_Base) && (menu_window_id < (cEditCombat_Menu_Base + AI2cCombatRange_NumStoredRanges))) {
 					combat_osd->behavior[menu_window_id - cEditCombat_Menu_Base] = menu_item;
 				}
 				else if (menu_window_id == cEditCombat_MeleeWhen) {


### PR DESCRIPTION
On unaligned pointer access:
Most consumer computer platforms have no issue with unaligned pointer access. It could lead to weirdness with unexpected compiler optimizations if it assumes addresses can only take certain forms for certain types, but that can often be disabled with compiler-flags.
Nonetheless, getting rid of it may allow this to one day run properly on platforms that do not allow unaligned pointer access. The `memcpy` of small constant size are very likely inlined anyways, so I don't see an issue with changine these reads and writes to `memcpy`.

The next three commits should be pretty straight forward.
The next two, OOB string access and the overflow in `AI2rInitializeCharacter()` were a little less straight forward, since they necessitated understanding some of the code's logic. I hope the commit messages explain the respective situations well and also how/why the proposed fixes work.

On the side a little note on my progress on the Linux port:
I've previously showed a video with spazzing animations - the animations have been fixed.
The OpenAL integration is incomplete: It's missing code to decompress the audio data. From what I've read I already found out that it should be "MS ADPCM", an "IMA 4:1" compression. I intend to strip the decoding algorithm from libsox. It'll live as a separate shared library since that's LGPL licensed.
I require an input-handling workaround (208b08656a46d408cadbb95f495247ff1979da0d), the cause of which would probably need to be investigated using a profiler. It looks to me like the workaround works well enough, so I intend to keep it when I eventually make my SDL/Linux PR and leave it for future enhancement.
The only thing that would need fixing up then, apart from the audio decompression, is properly setting up the initial display mode. That's likely a relatively simple fix, I've just invested my time tackling the "bigger" issues.
So all in all it looks to be in good shape.